### PR TITLE
.github: migrate from node-16 to node-20

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           submodules: true    # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0      # Fetch all history for .GitInfo and .Lastmod
@@ -19,10 +19,10 @@ jobs:
       - name: Hugo setup
         uses: peaceiris/actions-hugo@v2.6.0
         with:
-          hugo-version: "0.105.0"
+          hugo-version: "0.111.3"
           extended: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4.0.0
         with:
           path: /tmp/hugo_cache
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
@@ -35,7 +35,7 @@ jobs:
         run: hugo --minify
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.9.3
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/seo.yml
+++ b/.github/workflows/seo.yml
@@ -12,10 +12,10 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.8.0
+        uses: lycheeverse/lychee-action@v1.9.2
         with:
           fail: true
           args: --max-redirects 10 -a 403,500,503 .
@@ -24,17 +24,17 @@ jobs:
     name: Check orphan pages
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 
       - name: Checkout SEO Spy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: 3mdeb/seo-spy
           path: seo-spy
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -44,7 +44,7 @@ jobs:
           pip install -r seo-spy/requirements.txt
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v2.6.0
         with:
           extended: true
 
@@ -64,17 +64,17 @@ jobs:
     name: Check canonical links
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           submodules: true
 
       - name: Checkout SEO Spy
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
         with:
           repository: 3mdeb/seo-spy
           path: seo-spy
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -84,7 +84,7 @@ jobs:
           pip install -r seo-spy/requirements.txt
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v2.6.0
         with:
           extended: true
 


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, peaceiris/actions-hugo@v2.6.0, actions/cache@v2. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.