### PR TITLE
layouts/: add bsmconf-banner element

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,4 @@
 themes/dasharo/layouts/
+layouts/
 http://localhost:1313/
 .Params.email

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -37,9 +37,9 @@ mailchimp_form_name = "b_463ee871f45d2d93748e77cad_a0a2c6d074"                  
 #   call-for-sponsors  — sponsorship slots open, warm/light strip
 #   call-for-papers    — CfP open, green gradient strip
 #   early-bird         — tickets live with early-bird pricing, dark strip
-#   schedule-announced — CfP closed, full program announced, light strip
+#   program-live       — CfP closed, full program announced, light strip
 #   last-chance        — final tickets, dark red strip
-#   happening-now      — conference live, dark strip with animated green dot
+#   live               — conference live, dark strip with animated green dot
 # Changing the stage resets the dismiss state for all visitors.
 [bsmconf_banner]
 enable = true

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -30,6 +30,21 @@ enable = false
 mailchimp_form_action = "https://gmail.us4.list-manage.com/subscribe/post?u=463ee871f45d2d93748e77cad&amp;id=a0a2c6d074" # replace this url with yours
 mailchimp_form_name = "b_463ee871f45d2d93748e77cad_a0a2c6d074"                                                           # replace this code with yours
 
+# BSMconf 2026 conference banner
+# Set enable = false to hide the banner entirely.
+# Stages in chronological order (pick one active stage at a time):
+#   save-the-date      — early announcement, dark/neutral strip
+#   call-for-sponsors  — sponsorship slots open, warm/light strip
+#   call-for-papers    — CfP open, green gradient strip
+#   early-bird         — tickets live with early-bird pricing, dark strip
+#   schedule-announced — CfP closed, full program announced, light strip
+#   last-chance        — final tickets, dark red strip
+#   happening-now      — conference live, dark strip with animated green dot
+# Changing the stage resets the dismiss state for all visitors.
+[bsmconf_banner]
+enable = true
+stage  = "save-the-date"
+
 ############################# social site ########################
 
 [[social]]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="{{ site.LanguageCode | default `en-US` }}" itemscope itemtype="http://schema.org/WebPage">
+
+<head>
+  {{ if .Site.Params.googleAnalytics }}
+    {{ partial "essentials/analytics-gtag.html" . }}
+  {{ end }}
+
+	<!-- head (don't cache it) -->
+	{{ partial "essentials/head.html" . }}
+
+	<!-- cache partial only in production -->
+	{{ if hugo.IsProduction }}
+	{{ partialCached "essentials/style.html" . }}
+	{{ else }}
+	{{ partial "essentials/style.html" . }}
+	{{ end }}
+
+	<!-- manifest -->
+	{{ partialCached "manifest" . }}
+
+	<!-- site verifications -->
+	{{ partialCached "site-verifications.html" . }}
+
+	<!-- opengraph and twitter card -->
+	{{ partial "basic-seo.html" . }}
+
+	<!-- google tag manager -->
+	{{ partialCached "components/gtm.html" . }}
+</head>
+
+<body>
+	<!-- cache partial only in production -->
+	{{ if hugo.IsProduction }}
+	{{ with site.Params.google_tag_manager }}
+	<noscript>
+		<iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+	</noscript>
+	{{ end }}
+	{{ end }}
+
+	<!-- BSMconf 2026 banner -->
+	{{ partial "bsmconf-banner.html" . }}
+
+	<!-- header (don't cache it) -->
+	{{ partial "essentials/header.html" . }}
+
+	<main>
+		{{ block "main" . }}{{ end }}
+	</main>
+
+	<!-- cache partial only in production -->
+	{{ if hugo.IsProduction }}
+	{{ partialCached "essentials/footer.html" . }}
+	{{ partialCached "essentials/script.html" . }}
+	{{ else }}
+	{{ partial "essentials/footer.html" . }}
+	{{ partial "essentials/script.html" . }}
+	{{ end }}
+</body>
+
+</html>

--- a/layouts/partials/bsmconf-banner.html
+++ b/layouts/partials/bsmconf-banner.html
@@ -1,0 +1,186 @@
+{{ $banner := site.Params.bsmconf_banner }}
+{{ if and $banner $banner.enable }}
+{{ $stage := $banner.stage | default "save-the-date" }}
+{{ $link  := "https://3mdeb.com/events/#_boot-security-mastery-conference" }}
+{{ $key   := printf "bsm26-banner-%s" $stage }}
+
+<style>
+:root{--bsm-h:40px}
+.navigation__container{top:var(--bsm-h)!important}
+#bsmconf-banner{width:100%;box-sizing:border-box;display:flex;align-items:center;justify-content:center;gap:14px;padding:10px 48px 10px 16px;position:fixed;top:0;left:0;z-index:20;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:1.2;letter-spacing:.1px}
+#bsmconf-banner .bsm-content{display:inline-flex;align-items:center;flex-wrap:wrap;justify-content:center;gap:10px}
+#bsmconf-banner .bsm-cta{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:4px;font-weight:600;text-decoration:none;font-size:13px;letter-spacing:.2px;white-space:nowrap;transition:opacity .12s}
+#bsmconf-banner .bsm-cta:hover{opacity:.85}
+#bsmconf-banner .bsm-dismiss{position:absolute;right:10px;top:50%;transform:translateY(-50%);background:transparent;border:none;cursor:pointer;padding:6px;line-height:0;opacity:.55;border-radius:4px}
+#bsmconf-banner .bsm-dismiss:hover{opacity:1}
+#bsmconf-banner .bsm-pill{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:.8px;text-transform:uppercase}
+#bsmconf-banner .bsm-dot{display:inline-block;width:6px;height:6px;border-radius:999px;margin-right:8px;flex:none}
+@keyframes bsm-pulse{0%,100%{opacity:1}50%{opacity:.35}}
+#bsmconf-banner .bsm-live-dot{display:inline-block;width:6px;height:6px;border-radius:999px;background:#062712;margin-right:6px;animation:bsm-pulse 1.4s infinite}
+</style>
+
+{{ if eq $stage "save-the-date" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#0b0d12;color:#e6e8ec;">
+  <span class="bsm-content">
+    <span class="bsm-dot" style="background:#8ab4ff;"></span>
+    <strong>BSMconf 2026</strong>
+    <span style="opacity:.55;">·</span>
+    <span style="opacity:.85;">Boot Security Mastery Conference</span>
+    <span style="opacity:.55;">·</span>
+    <span style="opacity:.85;">Save the date</span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#e6e8ec;color:#0b0d12;">
+    Learn more
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#e6e8ec" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "call-for-sponsors" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#fffaf0;color:#3f2d10;border-bottom:1px solid #f1e3c2;">
+  <span class="bsm-content">
+    <span class="bsm-pill" style="background:#3f2d10;color:#fffaf0;">BSMconf 2026</span>
+    <span>
+      <strong>Sponsorship slots open</strong>
+      <span style="opacity:.75;"> — back the only conference dedicated to boot &amp; firmware security.</span>
+    </span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#1f2937;color:#fff;">
+    Become a sponsor
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#3f2d10" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "call-for-papers" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:linear-gradient(90deg,#0b3d2e 0%,#0e5239 100%);color:#eafff5;">
+  <span class="bsm-content">
+    <span class="bsm-pill" style="background:rgba(255,255,255,.14);color:#eafff5;">CfP Open</span>
+    <span>
+      <strong>BSMconf 2026</strong>
+      <span style="opacity:.8;"> — Call for Papers closes soon. Share your firmware-security research.</span>
+    </span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#eafff5;color:#0b3d2e;">
+    Submit your talk
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#eafff5" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "early-bird" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#111827;color:#e5e7eb;">
+  <span class="bsm-content">
+    <span class="bsm-pill" style="background:#a3e635;color:#111827;">Early bird</span>
+    <span>
+      <strong>BSMconf 2026 tickets are live.</strong>
+      <span style="opacity:.75;"> Early-bird pricing until CfP closes.</span>
+    </span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#a3e635;color:#111827;">
+    Get early-bird ticket
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#e5e7eb" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "schedule-announced" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#fdfdfd;color:#0b0d12;border-bottom:1px solid #e4e4e7;">
+  <span class="bsm-content">
+    <span class="bsm-pill" style="background:#0b0d12;color:#fdfdfd;">Program live</span>
+    <span>
+      <strong>BSMconf 2026</strong>
+      <span style="opacity:.7;"> — full speaker line-up announced. Standard tickets on sale.</span>
+    </span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#0b0d12;color:#fdfdfd;">
+    See the program
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#0b0d12" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "last-chance" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#7f1d1d;color:#fff1f1;">
+  <span class="bsm-content">
+    <span class="bsm-dot" style="background:#fca5a5;"></span>
+    <strong>BSMconf 2026 — final tickets</strong>
+    <span style="opacity:.85;">Conference starts in 2 weeks. Seats running low.</span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#fff1f1;color:#7f1d1d;">
+    Grab a seat
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#fff1f1" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+
+{{ else if eq $stage "happening-now" }}
+<div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#0b0d12;color:#e6e8ec;">
+  <span class="bsm-content">
+    <span class="bsm-pill" style="background:#22c55e;color:#062712;">
+      <span class="bsm-live-dot"></span>Live now
+    </span>
+    <span>
+      <strong>BSMconf 2026 is happening.</strong>
+      <span style="opacity:.75;"> Talks streaming all week.</span>
+    </span>
+  </span>
+  <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#22c55e;color:#062712;">
+    Watch live
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <button class="bsm-dismiss" aria-label="Dismiss banner">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#e6e8ec" stroke-width="1.5" stroke-linecap="round"/></svg>
+  </button>
+</div>
+{{ end }}
+
+<script>
+// Synchronous: handle dismissed state before DOMContentLoaded to avoid nav flash.
+(function(){
+  var el=document.getElementById('bsmconf-banner');
+  if(!el)return;
+  if(localStorage.getItem(el.dataset.bsmKey)==='dismissed'){
+    el.style.display='none';
+    document.documentElement.style.setProperty('--bsm-h','0px');
+  }
+})();
+
+document.addEventListener('DOMContentLoaded',function(){
+  var el=document.getElementById('bsmconf-banner');
+  if(!el||el.style.display==='none')return;
+  var key=el.dataset.bsmKey;
+  var nav=document.querySelector('.navigation__container');
+  var main=document.querySelector('main');
+
+  function applyOffsets(){
+    var bh=el.offsetHeight;
+    document.documentElement.style.setProperty('--bsm-h',bh+'px');
+    if(main) main.style.paddingTop=bh+'px';
+  }
+
+  function dismiss(){
+    localStorage.setItem(key,'dismissed');
+    el.style.display='none';
+    document.documentElement.style.setProperty('--bsm-h','0px');
+    if(main) main.style.paddingTop='0';
+  }
+
+  applyOffsets();
+  window.addEventListener('resize',applyOffsets);
+  el.querySelector('.bsm-dismiss').addEventListener('click',dismiss);
+});
+</script>
+{{ end }}

--- a/layouts/partials/bsmconf-banner.html
+++ b/layouts/partials/bsmconf-banner.html
@@ -1,7 +1,8 @@
 {{ $banner := site.Params.bsmconf_banner }}
 {{ if and $banner $banner.enable }}
 {{ $stage := $banner.stage | default "save-the-date" }}
-{{ $link  := "https://3mdeb.com/events/#_boot-security-mastery-conference" }}
+{{ $link    := "https://3mdeb.com/events/#_boot-security-mastery-conference" }}
+{{ $tickets := "https://events.dasharo.com/event/11/boot-security-mastery-conference-2026" }}
 {{ $key   := printf "bsm26-banner-%s" $stage }}
 
 <style>
@@ -11,12 +12,18 @@
 #bsmconf-banner .bsm-content{display:inline-flex;align-items:center;flex-wrap:wrap;justify-content:center;gap:10px}
 #bsmconf-banner .bsm-cta{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:4px;font-weight:600;text-decoration:none;font-size:13px;letter-spacing:.2px;white-space:nowrap;transition:opacity .12s}
 #bsmconf-banner .bsm-cta:hover{opacity:.85}
+#bsmconf-banner .bsm-cta-tickets{background:transparent;border:1.5px solid currentColor}
 #bsmconf-banner .bsm-dismiss{position:absolute;right:10px;top:50%;transform:translateY(-50%);background:transparent;border:none;cursor:pointer;padding:6px;line-height:0;opacity:.55;border-radius:4px}
 #bsmconf-banner .bsm-dismiss:hover{opacity:1}
 #bsmconf-banner .bsm-pill{display:inline-flex;align-items:center;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;letter-spacing:.8px;text-transform:uppercase}
 #bsmconf-banner .bsm-dot{display:inline-block;width:6px;height:6px;border-radius:999px;margin-right:8px;flex:none}
 @keyframes bsm-pulse{0%,100%{opacity:1}50%{opacity:.35}}
 #bsmconf-banner .bsm-live-dot{display:inline-block;width:6px;height:6px;border-radius:999px;background:#062712;margin-right:6px;animation:bsm-pulse 1.4s infinite}
+@media(max-width:768px){
+  #bsmconf-banner{flex-wrap:wrap;padding:10px 16px;row-gap:8px}
+  #bsmconf-banner .bsm-content{width:100%;padding-right:28px}
+  #bsmconf-banner .bsm-dismiss{top:12px;transform:none}
+}
 </style>
 
 {{ if eq $stage "save-the-date" }}
@@ -31,6 +38,10 @@
   </span>
   <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#e6e8ec;color:#0b0d12;">
     Learn more
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#e6e8ec;">
+    Get tickets
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">
@@ -51,6 +62,10 @@
     Become a sponsor
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#3f2d10;">
+    Get tickets
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">
     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#3f2d10" stroke-width="1.5" stroke-linecap="round"/></svg>
   </button>
@@ -67,6 +82,10 @@
   </span>
   <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#eafff5;color:#0b3d2e;">
     Submit your talk
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#eafff5;">
+    Get tickets
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">
@@ -87,6 +106,10 @@
     Get early-bird ticket
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#e5e7eb;">
+    Get tickets
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">
     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#e5e7eb" stroke-width="1.5" stroke-linecap="round"/></svg>
   </button>
@@ -105,6 +128,10 @@
     See the program
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#0b0d12;">
+    Get tickets
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">
     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M2 2l8 8M10 2l-8 8" stroke="#0b0d12" stroke-width="1.5" stroke-linecap="round"/></svg>
   </button>
@@ -118,7 +145,11 @@
     <span style="opacity:.85;">Conference starts in 2 weeks. Seats running low.</span>
   </span>
   <a href="{{ $link }}" target="_blank" rel="noopener" class="bsm-cta" style="background:#fff1f1;color:#7f1d1d;">
-    Grab a seat
+    Learn more
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  </a>
+  <a href="{{ $tickets }}" target="_blank" rel="noopener" class="bsm-cta bsm-cta-tickets" style="color:#fff1f1;">
+    Get tickets
     <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true"><path d="M1 5h8M5.5 1.5L9 5l-3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
   </a>
   <button class="bsm-dismiss" aria-label="Dismiss banner">

--- a/layouts/partials/bsmconf-banner.html
+++ b/layouts/partials/bsmconf-banner.html
@@ -92,7 +92,7 @@
   </button>
 </div>
 
-{{ else if eq $stage "schedule-announced" }}
+{{ else if eq $stage "program-live" }}
 <div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#fdfdfd;color:#0b0d12;border-bottom:1px solid #e4e4e7;">
   <span class="bsm-content">
     <span class="bsm-pill" style="background:#0b0d12;color:#fdfdfd;">Program live</span>
@@ -126,7 +126,7 @@
   </button>
 </div>
 
-{{ else if eq $stage "happening-now" }}
+{{ else if eq $stage "live" }}
 <div id="bsmconf-banner" data-bsm-key="{{ $key }}" style="background:#0b0d12;color:#e6e8ec;">
   <span class="bsm-content">
     <span class="bsm-pill" style="background:#22c55e;color:#062712;">


### PR DESCRIPTION
- config/_default/params.toml - added [bsmconf_banner] with enable and stage params. To switch stages, change stage to one of: save-the-date, call-for-sponsors, call-for-papers, early-bird, schedule-announced, last-chance, happening-now. To hide the banner entirely, set enable = false.
- layouts/partials/bsmconf-banner.html - self-contained banner partial: all 7 stage variants in plain HTML/CSS, dismiss button wired to localStorage with key bsm26-banner-{stage}. Changing the stage key causes the banner to re-appear for all visitors.
- layouts/_default/baseof.html - overrides the theme's baseof.html (identical content) with {{ partial "bsmconf-banner.html" . }} on top.